### PR TITLE
Update appTitle href to include base path

### DIFF
--- a/src/UnisonLocal/App.elm
+++ b/src/UnisonLocal/App.elm
@@ -512,8 +512,8 @@ appTitle click =
         )
 
 
-appHeader : Bool -> AppHeader.AppHeader Msg
-appHeader isHelpAndResourcesMenuOpen =
+appHeader : String -> Bool -> AppHeader.AppHeader Msg
+appHeader basePath isHelpAndResourcesMenuOpen =
     let
         actionMenu =
             ActionMenu.items
@@ -531,7 +531,7 @@ appHeader isHelpAndResourcesMenuOpen =
                 |> ActionMenu.view
     in
     { menuToggle = Just ToggleSidebar
-    , appTitle = appTitle (Click.Href "/")
+    , appTitle = appTitle (Click.Href basePath)
     , navigation = Nothing
     , leftSide = []
     , viewMode = ViewMode.Regular
@@ -842,7 +842,7 @@ view model =
     { title = "Unison Local"
     , body =
         [ div [ id "app" ]
-            [ AppHeader.view (appHeader model.isHelpAndResourcesMenuOpen)
+            [ AppHeader.view (appHeader model.env.basePath model.isHelpAndResourcesMenuOpen)
             , PageLayout.view page
             , viewModal model
             ]


### PR DESCRIPTION
## Problem
[upper left Unison Local link is broken](https://github.com/unisonweb/unison-local-ui/issues/7)

## Solution
Setting basePath to `href` of the title.

## Caveats/Notes
I changed the code and confirmed it type-check, however, I wasn't able to test this behavior because I couldn't figure out how to change the basePath (or eventually how to run this with the actual UCM).
Could you check this or let me know how to test with the actual path?