### PR TITLE
Fix query parcent encoding

### DIFF
--- a/src/UnisonLocal/Api.elm
+++ b/src/UnisonLocal/Api.elm
@@ -92,7 +92,8 @@ codebaseApiEndpointToEndpoint cbEndpoint =
                 refToString r =
                     case Reference.hashQualified r of
                         HQ.NameOnly fqn ->
-                            FQN.toApiUrlString fqn
+                            -- Using plain `toString` here because percentEncoded is added in elm/url's query param builder below
+                            fqn |> FQN.toString
 
                         HQ.HashOnly h ->
                             withoutConstructorSuffix h


### PR DESCRIPTION
## Problem

Local UI errors when viewing symbol function operators 
#10 

It seems percent encoding is added twice, first with `FQN.toApiUrlString` then `Url.Builder.string`.
For example, for `base.data.List.++` definition, the query becomes this with the current logic `?names=base.data.List.%252B%252B`, which should be `?names=base.data.List.%2B%2B`.

## Solution

Using `FQN.toString` instead of `FQN.toApiUrlString`

I also checked with 🐢 ability.
https://share.unison-lang.org/@chrispenner/p/code/latest/types/public/turtle/%F0%9F%90%A2

