### PR TITLE
List projects on homepage

### DIFF
--- a/src/UnisonLocal/Api.elm
+++ b/src/UnisonLocal/Api.elm
@@ -1,4 +1,4 @@
-module UnisonLocal.Api exposing (codebaseApiEndpointToEndpoint, namespace)
+module UnisonLocal.Api exposing (codebaseApiEndpointToEndpoint, namespace, projects, projectBranches)
 
 import Code.BranchRef as BranchRef
 import Code.CodebaseApi as CodebaseApi
@@ -14,7 +14,7 @@ import Lib.HttpApi exposing (Endpoint(..))
 import Maybe.Extra as MaybeE
 import Regex
 import UnisonLocal.CodeBrowsingContext exposing (CodeBrowsingContext(..))
-import UnisonLocal.ProjectName as ProjectName
+import UnisonLocal.ProjectName as ProjectName exposing (ProjectName)
 import Url.Builder exposing (QueryParameter, int, string)
 
 
@@ -27,6 +27,22 @@ namespace context perspective fqn =
     GET
         { path = baseCodePathFromContext context ++ [ "namespaces", FQN.toString fqn ]
         , queryParams = MaybeE.values queryParams
+        }
+
+
+projects : Endpoint
+projects =
+    GET
+        { path = [ "projects" ]
+        , queryParams = []
+        }
+
+
+projectBranches : ProjectName -> Endpoint
+projectBranches projectName =
+    GET
+        { path = [ "projects", ProjectName.toApiString projectName, "branches" ]
+        , queryParams = []
         }
 
 

--- a/src/UnisonLocal/Link.elm
+++ b/src/UnisonLocal/Link.elm
@@ -1,7 +1,11 @@
 module UnisonLocal.Link exposing (..)
 
+import Code.BranchRef exposing (BranchRef)
+import Code.Perspective as Perspective
 import Html exposing (Html, text)
 import UI.Click as Click exposing (Click)
+import UnisonLocal.ProjectName exposing (ProjectName)
+import UnisonLocal.Route as Route exposing (Route)
 
 
 
@@ -13,6 +17,25 @@ import UI.Click as Click exposing (Click)
    Various UI.Click link helpers for Routes and external links
 
 -}
+-- ROUTES
+
+
+projectBranchRoot : ProjectName -> BranchRef -> Click msg
+projectBranchRoot projectName branchRef =
+    let
+        pers =
+            Perspective.relativeRootPerspective
+    in
+    Route.projectBranchRoot projectName branchRef pers
+        |> toClick
+
+
+toClick : Route -> Click msg
+toClick =
+    Route.toUrlString >> Click.href
+
+
+
 -- EXTERNAL
 
 

--- a/src/UnisonLocal/Page/HomePage.elm
+++ b/src/UnisonLocal/Page/HomePage.elm
@@ -183,22 +183,10 @@ view { projects } =
         appHeader =
             AppHeader.appHeader
 
-        nonProjectCodeParagraph =
-            p []
-                [ text "or "
-                , Route.nonProjectCodeRoot Perspective.relativeRootPerspective
-                    |> Route.toUrlString
-                    |> Click.href
-                    |> Click.view [] [ text "view all non-project code" ]
-                , text "."
-                ]
-
         page =
             PageLayout.centeredNarrowLayout
                 (PageContent.oneColumn
-                    (viewProjectList projects
-                        ++ [ nonProjectCodeParagraph ]
-                    )
+                    (viewProjectList projects)
                     |> PageContent.withPageTitle (PageTitle.title "Open a project branch")
                 )
                 (PageFooter [])

--- a/src/UnisonLocal/Page/HomePage.elm
+++ b/src/UnisonLocal/Page/HomePage.elm
@@ -1,42 +1,177 @@
 module UnisonLocal.Page.HomePage exposing (..)
 
+import Code.BranchRef as BranchRef exposing (BranchSlug(..))
+import Code.Perspective as Perspective
+import Html exposing (li, p, text, ul)
+import Json.Decode as Decode
+import Json.Decode.Pipeline exposing (required)
+import Lib.HttpApi as HttpApi
+import Lib.Util as Util
+import RemoteData exposing (RemoteData(..), WebData)
+import UI.Click as Click
 import UI.PageContent as PageContent
 import UI.PageLayout as PageLayout exposing (PageFooter(..))
-import UI.StatusBanner as StatusBanner
+import UI.PageTitle as PageTitle
+import UnisonLocal.Api as LocalApi
 import UnisonLocal.AppContext exposing (AppContext)
 import UnisonLocal.AppDocument as AppDocument exposing (AppDocument)
 import UnisonLocal.AppHeader as AppHeader
+import UnisonLocal.ProjectName as ProjectName exposing (ProjectName)
+import UnisonLocal.Route as Route
 
 
 type alias Model =
-    ()
+    { projects : List ProjectWithBranches }
+
+
+type alias ProjectWithBranches =
+    { projectName : ProjectName
+    , branches : List { branchName : BranchSlug }
+    }
 
 
 init : AppContext -> ( Model, Cmd Msg )
-init _ =
-    ( (), Cmd.none )
+init appContext =
+    let
+        fetchProjectsCmd =
+            fetchProjects FetchProjectsFinished
+                |> HttpApi.perform appContext.api
+    in
+    ( { projects = [] }
+    , fetchProjectsCmd
+    )
+
+
+fetchProjects :
+    (WebData (List { projectName : ProjectName }) -> msg)
+    -> HttpApi.ApiRequest (List { projectName : ProjectName }) msg
+fetchProjects finishedMsg =
+    LocalApi.projects
+        |> HttpApi.toRequest decodeProjectList (RemoteData.fromResult >> finishedMsg)
+
+
+fetchProjectBranches :
+    (WebData (List { branchName : BranchSlug }) -> msg)
+    -> ProjectName
+    -> HttpApi.ApiRequest (List { branchName : BranchSlug }) msg
+fetchProjectBranches finishedMsg projectName =
+    LocalApi.projectBranches projectName
+        |> HttpApi.toRequest decodeBranchList (RemoteData.fromResult >> finishedMsg)
+
+
+decodeProjectList : Decode.Decoder (List { projectName : ProjectName })
+decodeProjectList =
+    let
+        makeProjectName projectName =
+            { projectName = projectName }
+    in
+    Decode.succeed makeProjectName
+        |> required "projectName" ProjectName.decode
+        |> Decode.list
+
+
+decodeBranchList : Decode.Decoder (List { branchName : BranchSlug })
+decodeBranchList =
+    let
+        makeBranchName branchName =
+            { branchName = branchName }
+    in
+    Decode.succeed makeBranchName
+        |> required "branchName" branchSlugDecode
+        |> Decode.list
+
+
+branchSlugDecode : Decode.Decoder BranchSlug
+branchSlugDecode =
+    Decode.map BranchRef.branchSlugFromString Decode.string
+        |> Decode.andThen (Util.decodeFailInvalid "Invalid BranchName")
 
 
 type Msg
-    = NoOp
+    = FetchProjectsFinished (WebData (List { projectName : ProjectName }))
+    | FetchProjectBranchesFinished ProjectName (WebData (List { branchName : BranchSlug }))
 
 
 update : AppContext -> Msg -> Model -> ( Model, Cmd Msg )
-update _ _ model =
-    ( model, Cmd.none )
+update appContext msg model =
+    case msg of
+        FetchProjectsFinished (Success projects) ->
+            ( { projects =
+                    projects
+                        |> List.map (\{ projectName } -> ProjectWithBranches projectName [])
+              }
+            , let
+                fetchProjectBranchesCmd projectName =
+                    fetchProjectBranches (FetchProjectBranchesFinished projectName) projectName
+                        |> HttpApi.perform appContext.api
+              in
+              projects
+                |> List.map (\{ projectName } -> fetchProjectBranchesCmd projectName)
+                |> Cmd.batch
+            )
+
+        FetchProjectsFinished _ ->
+            ( model, Cmd.none )
+
+        FetchProjectBranchesFinished projectName (Success branches) ->
+            ( { projects =
+                    model.projects
+                        |> List.map
+                            (\project ->
+                                if project.projectName == projectName then
+                                    ProjectWithBranches project.projectName branches
+
+                                else
+                                    project
+                            )
+              }
+            , Cmd.none
+            )
+
+        FetchProjectBranchesFinished _ _ ->
+            ( model, Cmd.none )
 
 
 view : Model -> AppDocument Msg
-view _ =
+view { projects } =
     let
         appHeader =
             AppHeader.appHeader
 
+        projectList =
+            projects
+                |> List.map
+                    (\{ projectName, branches } ->
+                        let
+                            defaultBranch =
+                                List.head branches
+                                    |> Maybe.map (\{ branchName } -> branchName)
+                                    |> Maybe.withDefault (BranchSlug "main")
+                        in
+                        li []
+                            [ Click.href
+                                (String.join "/" [ "/projects", ProjectName.toString projectName, BranchRef.branchSlugToString defaultBranch ++ "/" ])
+                                |> Click.view [] [ text <| ProjectName.toString projectName ]
+                            ]
+                    )
+
+        nonProjectCodeParagraph =
+            p []
+                [ text "or "
+                , Route.nonProjectCodeRoot Perspective.relativeRootPerspective
+                    |> Route.toUrlString
+                    |> Click.href
+                    |> Click.view [] [ text "view all non-project code" ]
+                , text "."
+                ]
+
         page =
             PageLayout.centeredNarrowLayout
                 (PageContent.oneColumn
-                    [ StatusBanner.info "Type `ui` from within a Project in UCM to view that project."
+                    [ ul [] projectList
+                    , nonProjectCodeParagraph
                     ]
+                    |> PageContent.withPageTitle (PageTitle.title "Open a project")
                 )
                 (PageFooter [])
                 |> PageLayout.withSubduedBackground

--- a/src/UnisonLocal/Page/HomePage.elm
+++ b/src/UnisonLocal/Page/HomePage.elm
@@ -1,14 +1,12 @@
 module UnisonLocal.Page.HomePage exposing (..)
 
 import Code.BranchRef as BranchRef exposing (BranchSlug(..))
-import Code.Perspective as Perspective
 import Dict exposing (Dict)
 import Html exposing (Html, div, h2, p, text)
 import Json.Decode as Decode
 import Lib.HttpApi as HttpApi
 import Lib.Util as Util
 import RemoteData exposing (RemoteData(..), WebData)
-import UI.Click as Click
 import UI.PageContent as PageContent
 import UI.PageLayout as PageLayout exposing (PageFooter(..))
 import UI.PageTitle as PageTitle
@@ -17,8 +15,8 @@ import UnisonLocal.Api as LocalApi
 import UnisonLocal.AppContext exposing (AppContext)
 import UnisonLocal.AppDocument as AppDocument exposing (AppDocument)
 import UnisonLocal.AppHeader as AppHeader
+import UnisonLocal.Link as Link
 import UnisonLocal.ProjectName as ProjectName exposing (ProjectName)
-import UnisonLocal.Route as Route
 
 
 
@@ -142,15 +140,16 @@ viewProjectList : Projects -> List (Html Msg)
 viewProjectList projects =
     let
         branchTag projectName branchName =
-            BranchRef.projectBranchRef branchName
-                |> (\branchRef ->
-                        BranchRef.toTag branchRef
-                            |> Tag.withClick
-                                (Route.projectBranchRoot projectName branchRef Perspective.relativeRootPerspective
-                                    |> Route.toUrlString
-                                    |> Click.href
-                                )
-                   )
+            let
+                branchRef =
+                    BranchRef.projectBranchRef branchName
+
+                branchRootLink =
+                    Link.projectBranchRoot projectName branchRef
+            in
+            branchRef
+                |> BranchRef.toTag
+                |> Tag.withClick branchRootLink
                 |> Tag.view
 
         branchList projectName branches =


### PR DESCRIPTION
## Problem

When opening the homepage you are presented with an instruction to run the `ui` command in a project in UCM. This message can be confusing if you navigate to the homepage or if you have started a headless instance of UCM and connected to it with the development server.

## Solution

This solution lists the projects and each branch on the homepage for easier navigation.

![image](https://github.com/unisonweb/unison-local-ui/assets/28558941/5bc70634-178c-4042-8ea6-1e51c2865db2)


## Caveats/Notes

It was decided together with @hojberg to not use the `ProjectListing` component since it takes a Unison Share project as a parameter, but local projects are of another (simpler) type. There might be a way to put together these two project concepts, but it is out of scope for this PR.
